### PR TITLE
Features rfc7231 methods

### DIFF
--- a/src/Httpstatus.php
+++ b/src/Httpstatus.php
@@ -211,9 +211,24 @@ class Httpstatus implements Countable, IteratorAggregate
      */
     public function isInformational($code)
     {
-        $code = $this->filterHttpStatusCode($code);
+        return (bool) $this->formatInt($this->filterHttpStatusCode($code), 100, 199);
+    }
 
-        return ($code >= 100 && $code < 200);
+    /**
+     * Validate an integer between ranges
+     *
+     * @param int $int the integer to valid and format
+     * @param int $min the min range
+     * @param int $max the max range
+     *
+     * @return int|false return false if the integer is not valid
+     */
+    protected function formatInt($int, $min, $max)
+    {
+        return filter_var($int, FILTER_VALIDATE_INT, ['options' => [
+            'min_range' => $min,
+            'max_range' => $max,
+        ]]);
     }
 
     /**
@@ -227,9 +242,7 @@ class Httpstatus implements Countable, IteratorAggregate
      */
     public function isSuccessful($code)
     {
-        $code = $this->filterHttpStatusCode($code);
-
-        return ($code >= 200 && $code < 300);
+        return (bool) $this->formatInt($this->filterHttpStatusCode($code), 200, 299);
     }
 
     /**
@@ -243,9 +256,7 @@ class Httpstatus implements Countable, IteratorAggregate
      */
     public function isRedirection($code)
     {
-        $code = $this->filterHttpStatusCode($code);
-
-        return ($code >= 300 && $code < 400);
+        return (bool) $this->formatInt($this->filterHttpStatusCode($code), 300, 399);
     }
 
     /**
@@ -259,9 +270,7 @@ class Httpstatus implements Countable, IteratorAggregate
      */
     public function isClientError($code)
     {
-        $code = $this->filterHttpStatusCode($code);
-
-        return ($code >= 400 && $code < 500);
+        return (bool) $this->formatInt($this->filterHttpStatusCode($code), 400, 499);
     }
 
     /**
@@ -275,9 +284,7 @@ class Httpstatus implements Countable, IteratorAggregate
      */
     public function isServerError($code)
     {
-        $code = $this->filterHttpStatusCode($code);
-
-        return ($code >= 400 && $code < 500);
+        return (bool) $this->formatInt($this->filterHttpStatusCode($code), 500, 599);
     }
 
     /**
@@ -315,10 +322,7 @@ class Httpstatus implements Countable, IteratorAggregate
     {
         $code = $this->filterHttpStatusCode($code);
         foreach ($this->unassignedRangeList as $range) {
-            if (filter_var($code, FILTER_VALIDATE_INT, ['options' => [
-                'min_range' => $range['min'],
-                'max_range' => $range['max'],
-            ]])) {
+            if ($this->formatInt($code, $range['min'], $range['max'])) {
                 return true;
             }
         }
@@ -375,11 +379,7 @@ class Httpstatus implements Countable, IteratorAggregate
      */
     protected function filterHttpStatusCode($code)
     {
-        $code = filter_var($code, FILTER_VALIDATE_INT, ['options' => [
-            'min_range' => self::MINIMUM,
-            'max_range' => self::MAXIMUM,
-        ]]);
-        if (!$code) {
+        if (!($code = $this->formatInt($code, self::MINIMUM, self::MAXIMUM))) {
             throw new InvalidArgumentException(
                 'The submitted code must be a positive integer between '.self::MINIMUM.' and '.self::MAXIMUM
             );

--- a/src/Httpstatus.php
+++ b/src/Httpstatus.php
@@ -110,64 +110,64 @@ class Httpstatus implements Countable, IteratorAggregate
      * @see http://www.iana.org/assignments/http-status-codes/http-status-codes.xhtml
      */
     protected $httpStatus = [
-      100 => 'Continue',
-      101 => 'Switching Protocols',
-      102 => 'Processing',
-      200 => 'OK',
-      201 => 'Created',
-      202 => 'Accepted',
-      203 => 'Non-Authoritative Information',
-      204 => 'No Content',
-      205 => 'Reset Content',
-      206 => 'Partial Content',
-      207 => 'Multi-Status',
-      208 => 'Already Reported',
-      226 => 'IM Used',
-      300 => 'Multiple Choices',
-      301 => 'Moved Permanently',
-      302 => 'Found',
-      303 => 'See Other',
-      304 => 'Not Modified',
-      305 => 'Use Proxy',
-      307 => 'Temporary Redirect',
-      308 => 'Permanent Redirect',
-      400 => 'Bad Request',
-      401 => 'Unauthorized',
-      402 => 'Payment Required',
-      403 => 'Forbidden',
-      404 => 'Not Found',
-      405 => 'Method Not Allowed',
-      406 => 'Not Acceptable',
-      407 => 'Proxy Authentication Required',
-      408 => 'Request Timeout',
-      409 => 'Conflict',
-      410 => 'Gone',
-      411 => 'Length Required',
-      412 => 'Precondition Failed',
-      413 => 'Payload Too Large',
-      414 => 'URI Too Long',
-      415 => 'Unsupported Media Type',
-      416 => 'Range Not Satisfiable',
-      417 => 'Expectation Failed',
-      421 => 'Misdirected Request',
-      422 => 'Unprocessable Entity',
-      423 => 'Locked',
-      424 => 'Failed Dependency',
-      426 => 'Upgrade Required',
-      428 => 'Precondition Required',
-      429 => 'Too Many Requests',
-      431 => 'Request Header Fields Too Large',
-      500 => 'Internal Server Error',
-      501 => 'Not Implemented',
-      502 => 'Bad Gateway',
-      503 => 'Service Unavailable',
-      504 => 'Gateway Timeout',
-      505 => 'HTTP Version Not Supported',
-      506 => 'Variant Also Negotiates',
-      507 => 'Insufficient Storage',
-      508 => 'Loop Detected',
-      510 => 'Not Extended',
-      511 => 'Network Authentication Required',
+        100 => 'Continue',
+        101 => 'Switching Protocols',
+        102 => 'Processing',
+        200 => 'OK',
+        201 => 'Created',
+        202 => 'Accepted',
+        203 => 'Non-Authoritative Information',
+        204 => 'No Content',
+        205 => 'Reset Content',
+        206 => 'Partial Content',
+        207 => 'Multi-Status',
+        208 => 'Already Reported',
+        226 => 'IM Used',
+        300 => 'Multiple Choices',
+        301 => 'Moved Permanently',
+        302 => 'Found',
+        303 => 'See Other',
+        304 => 'Not Modified',
+        305 => 'Use Proxy',
+        307 => 'Temporary Redirect',
+        308 => 'Permanent Redirect',
+        400 => 'Bad Request',
+        401 => 'Unauthorized',
+        402 => 'Payment Required',
+        403 => 'Forbidden',
+        404 => 'Not Found',
+        405 => 'Method Not Allowed',
+        406 => 'Not Acceptable',
+        407 => 'Proxy Authentication Required',
+        408 => 'Request Timeout',
+        409 => 'Conflict',
+        410 => 'Gone',
+        411 => 'Length Required',
+        412 => 'Precondition Failed',
+        413 => 'Payload Too Large',
+        414 => 'URI Too Long',
+        415 => 'Unsupported Media Type',
+        416 => 'Range Not Satisfiable',
+        417 => 'Expectation Failed',
+        421 => 'Misdirected Request',
+        422 => 'Unprocessable Entity',
+        423 => 'Locked',
+        424 => 'Failed Dependency',
+        426 => 'Upgrade Required',
+        428 => 'Precondition Required',
+        429 => 'Too Many Requests',
+        431 => 'Request Header Fields Too Large',
+        500 => 'Internal Server Error',
+        501 => 'Not Implemented',
+        502 => 'Bad Gateway',
+        503 => 'Service Unavailable',
+        504 => 'Gateway Timeout',
+        505 => 'HTTP Version Not Supported',
+        506 => 'Variant Also Negotiates',
+        507 => 'Insufficient Storage',
+        508 => 'Loop Detected',
+        510 => 'Not Extended',
+        511 => 'Network Authentication Required',
     ];
 
     /**
@@ -180,22 +180,27 @@ class Httpstatus implements Countable, IteratorAggregate
      */
     public function __construct($statusArray = [])
     {
-        $this->defaultHttpStatus = $this->httpStatus;
-
         foreach ($this->filterCollection($statusArray) as $code => $text) {
             $this->mergeHttpStatus($code, $text);
         }
     }
 
+    /**
+     * {@inheritdoc}
+     */
     public function count()
     {
         return count($this->httpStatus);
     }
 
+    /**
+     * {@inheritdoc}
+     */
     public function getIterator()
     {
         return new ArrayIterator($this->httpStatus);
     }
+
     /**
      * Tell whether the status code is informational
      *
@@ -290,11 +295,25 @@ class Httpstatus implements Countable, IteratorAggregate
         return $code >= 600;
     }
 
+    /**
+     * Tell whether the submitted code is a unused status code
+     *
+     * @param int $code
+     *
+     * @return bool
+     */
     public function isUnused($code)
     {
         return 306 === $this->filterHttpStatusCode($code);
     }
 
+    /**
+     * Tell whether the submitted code is an unassigned status code
+     *
+     * @param int $code
+     *
+     * @return bool
+     */
     public function isUnassigned($code)
     {
         $code = $this->filterHttpStatusCode($code);

--- a/src/Httpstatus.php
+++ b/src/Httpstatus.php
@@ -94,7 +94,6 @@ class Httpstatus implements Countable, IteratorAggregate
         ['min' => 227, 'max' => 299],
         ['min' => 309, 'max' => 399],
         ['min' => 418, 'max' => 420],
-        ['min' => 425, 'max' => 425],
         ['min' => 427, 'max' => 427],
         ['min' => 430, 'max' => 430],
         ['min' => 432, 'max' => 499],
@@ -290,13 +289,11 @@ class Httpstatus implements Countable, IteratorAggregate
      */
     public function isCustom($code)
     {
-        $code = $this->filterHttpStatusCode($code);
-
-        return $code >= 600;
+        return 600 <= $this->filterHttpStatusCode($code);
     }
 
     /**
-     * Tell whether the submitted code is a unused status code
+     * Tell whether the submitted code is a unused status code By IANA
      *
      * @param int $code
      *
@@ -308,7 +305,7 @@ class Httpstatus implements Countable, IteratorAggregate
     }
 
     /**
-     * Tell whether the submitted code is an unassigned status code
+     * Tell whether the submitted code is an unassigned status code By IANA
      *
      * @param int $code
      *

--- a/tests/HttpstatusTest.php
+++ b/tests/HttpstatusTest.php
@@ -330,10 +330,10 @@ class HttpstatusTest extends PHPUnit_Framework_TestCase
     public function isServerErrorProvider()
     {
         return [
-            'too low' => [399, false],
-            'included' => [400, true],
-            'custom' => [460, true],
-            'too high' => [500, false],
+            'too low' => [499, false],
+            'included' => [500, true],
+            'custom' => [560, true],
+            'too high' => [600, false],
         ];
     }
 

--- a/tests/HttpstatusTest.php
+++ b/tests/HttpstatusTest.php
@@ -223,4 +223,157 @@ class HttpstatusTest extends PHPUnit_Framework_TestCase
         $this->assertSame(true, $Httpstatus->hasReasonPhrase('Custom error code'), 'Expected $Httpstatus->hasReasonPhrase("Custom error code") to return true');
         $this->assertSame(false, $Httpstatus->hasReasonPhrase('MissingReasonPhrase'), 'Expected $Httpstatus->hasReasonPhrase("MissingReasonPhrase") to return false');
     }
+
+    /**
+     * @dataProvider isInformationalProvider
+     */
+    public function testIsInformational($code, $expected)
+    {
+        $this->assertSame($expected, $this->httpStatus->isInformational($code));
+    }
+
+    public function isInformationalProvider()
+    {
+        return [
+            'included' => [100, true],
+            'custom' => [120, true],
+            'non included' => [200, false],
+        ];
+    }
+
+    /**
+     * @dataProvider isSuccesfulProvider
+     */
+    public function testIsSuccesful($code, $expected)
+    {
+        $this->assertSame($expected, $this->httpStatus->isSuccessful($code));
+    }
+
+    public function isSuccesfulProvider()
+    {
+        return [
+            'too low' => [199, false],
+            'included' => [200, true],
+            'custom' => [220, true],
+            'too high' => [300, false],
+        ];
+    }
+
+    /**
+     * @dataProvider isRedirectionProvider
+     */
+    public function testIsRedirection($code, $expected)
+    {
+        $this->assertSame($expected, $this->httpStatus->isRedirection($code));
+    }
+
+    public function isRedirectionProvider()
+    {
+        return [
+            'too low' => [299, false],
+            'included' => [300, true],
+            'custom' => [320, true],
+            'too high' => [400, false],
+        ];
+    }
+
+    /**
+     * @dataProvider isClientErrorProvider
+     */
+    public function testIsClientError($code, $expected)
+    {
+        $this->assertSame($expected, $this->httpStatus->isClientError($code));
+    }
+
+    public function isClientErrorProvider()
+    {
+        return [
+            'too low' => [399, false],
+            'included' => [400, true],
+            'custom' => [460, true],
+            'too high' => [500, false],
+        ];
+    }
+
+    /**
+     * @dataProvider isServerErrorProvider
+     */
+    public function testIsServerError($code, $expected)
+    {
+        $this->assertSame($expected, $this->httpStatus->isServerError($code));
+    }
+
+    public function isServerErrorProvider()
+    {
+        return [
+            'too low' => [399, false],
+            'included' => [400, true],
+            'custom' => [460, true],
+            'too high' => [500, false],
+        ];
+    }
+
+    /**
+     * @dataProvider isCustomProvider
+     */
+    public function testIsCustom($code, $expected)
+    {
+        $this->assertSame($expected, $this->httpStatus->isCustom($code));
+    }
+
+    public function isCustomProvider()
+    {
+        return [
+            'too low' => [599, false],
+            'included' => [600, true],
+        ];
+    }
+
+    /**
+     * @dataProvider isUnusedProvider
+     */
+    public function testIsUnused($code, $expected)
+    {
+        $this->assertSame($expected, $this->httpStatus->isUnused($code));
+    }
+
+    public function isUnusedProvider()
+    {
+        return [
+            'too low' => [800, false],
+            'included' => [306, true],
+        ];
+    }
+
+    /**
+     * @dataProvider isUnassignedProvider
+     */
+    public function testIsUnassigned($code, $expected)
+    {
+        $this->assertSame($expected, $this->httpStatus->isUnassigned($code));
+    }
+
+    public function isUnassignedProvider()
+    {
+        return [
+            'is assigned' => [100, false],
+            'custom informational start range 1' => [103, true],
+            'custom informational end range 1' => [199, true],
+            'custom successful start range 1' => [209, true],
+            'custom successful end range 1' => [225, true],
+            'custom successful start range 2' => [227, true],
+            'custom successful end range 2' => [299, true],
+            'custom redirection start range 1' => [309, true],
+            'custom redirection end range 1' => [399, true],
+            'custom client error start range 1' => [418, true],
+            'custom client error end range 1' => [420, true],
+            'custom client error 2' => [427, true],
+            'custom client error 3' => [430, true],
+            'custom client error start range 4' => [432, true],
+            'custom client error end range 4' => [499, true],
+            'custom server error 1' => [509, true],
+            'custom server error start range 2' => [512, true],
+            'custom server error end range 2' => [599, true],
+        ];
+    }
 }

--- a/tests/HttpstatusTest.php
+++ b/tests/HttpstatusTest.php
@@ -381,6 +381,7 @@ class HttpstatusTest extends PHPUnit_Framework_TestCase
     {
         return [
             'is assigned' => [100, false],
+            'is custom' => [600, false],
             'custom informational start range 1' => [103, true],
             'custom informational end range 1' => [199, true],
             'custom successful start range 1' => [209, true],

--- a/tests/HttpstatusTest.php
+++ b/tests/HttpstatusTest.php
@@ -133,7 +133,7 @@ class HttpstatusTest extends PHPUnit_Framework_TestCase
             101 => 'Continue',
             404 => 'Look somewhere else',
             404 => 'Look somewhere else', // duplicate intended for testing
-            600 => 'Custom error code',
+            599 => 'Custom error code',
         ];
         $Httpstatus = new Httpstatus($custom);
 
@@ -141,7 +141,7 @@ class HttpstatusTest extends PHPUnit_Framework_TestCase
         $this->assertSame($custom[101], $Httpstatus->getReasonPhrase(101), 'Expected $Httpstatus->getReasonPhrase("101") to return '.$custom[101]);
         $this->assertSame($this->statuses[200], $Httpstatus->getReasonPhrase(200), 'Expected $Httpstatus->getReasonPhrase("200") to return '.$this->statuses[200]);
         $this->assertSame($custom[404], $Httpstatus->getReasonPhrase(404), 'Expected $Httpstatus->getReasonPhrase("404") to return '.$custom[404]);
-        $this->assertSame($custom[600], $Httpstatus->getReasonPhrase(600), 'Expected $Httpstatus->getReasonPhrase("600") to return '.$custom[600]);
+        $this->assertSame($custom[599], $Httpstatus->getReasonPhrase(599), 'Expected $Httpstatus->getReasonPhrase("599") to return '.$custom[599]);
     }
 
     public function testConstants()
@@ -161,7 +161,7 @@ class HttpstatusTest extends PHPUnit_Framework_TestCase
      */
     public function testInvalidIndexCode()
     {
-        (new Httpstatus())->getReasonPhrase(600);
+        (new Httpstatus())->getReasonPhrase(418);
     }
 
     /**
@@ -227,19 +227,19 @@ class HttpstatusTest extends PHPUnit_Framework_TestCase
     public function testHasStatusCode()
     {
         $custom = [
-            600 => 'Custom error code',
+            599 => 'Custom error code',
         ];
         $Httpstatus = new Httpstatus($custom);
 
         $this->assertSame(true, $Httpstatus->hasStatusCode(100), 'Expected $Httpstatus->hasStatusCode("100") to return true');
-        $this->assertSame(true, $Httpstatus->hasStatusCode(600), 'Expected $Httpstatus->hasStatusCode("600") to return true');
-        $this->assertSame(false, $Httpstatus->hasStatusCode(601), 'Expected $Httpstatus->hasStatusCode("601") to return false');
+        $this->assertSame(true, $Httpstatus->hasStatusCode(599), 'Expected $Httpstatus->hasStatusCode("599") to return true');
+        $this->assertSame(false, $Httpstatus->hasStatusCode(540), 'Expected $Httpstatus->hasStatusCode("540") to return false');
     }
 
     public function testHasReasonPhrase()
     {
         $custom = [
-            600 => 'Custom error code',
+            599 => 'Custom error code',
         ];
         $Httpstatus = new Httpstatus($custom);
 
@@ -333,39 +333,6 @@ class HttpstatusTest extends PHPUnit_Framework_TestCase
             'too low' => [499, false],
             'included' => [500, true],
             'custom' => [560, true],
-            'too high' => [600, false],
-        ];
-    }
-
-    /**
-     * @dataProvider isCustomProvider
-     */
-    public function testIsCustom($code, $expected)
-    {
-        $this->assertSame($expected, $this->httpStatus->isCustom($code));
-    }
-
-    public function isCustomProvider()
-    {
-        return [
-            'too low' => [599, false],
-            'included' => [600, true],
-        ];
-    }
-
-    /**
-     * @dataProvider isUnusedProvider
-     */
-    public function testIsUnused($code, $expected)
-    {
-        $this->assertSame($expected, $this->httpStatus->isUnused($code));
-    }
-
-    public function isUnusedProvider()
-    {
-        return [
-            'too low' => [800, false],
-            'included' => [306, true],
         ];
     }
 
@@ -381,7 +348,6 @@ class HttpstatusTest extends PHPUnit_Framework_TestCase
     {
         return [
             'is assigned' => [100, false],
-            'is custom' => [600, false],
             'custom informational start range 1' => [103, true],
             'custom informational end range 1' => [199, true],
             'custom successful start range 1' => [209, true],


### PR DESCRIPTION
I've added the following methods to make the class even more useful:
- `Http::isInformational` tell whether the submitted code is an informational code
- `Http::isSuccessful` tell whether the submitted code is a successful code 
- `Http::isRedirection` tell whether the submitted code is a redirection code
- `Http::isClientError` tell whether the submitted code is a client error code
- `Http::isServerError` tell whether the submitted code is a server error code 
- `Http::isUnassigned` tell whether the submitted code is a unassigned code by IANA
- `Http::isCustom` tell whether the submitted code is considered custom in regard to RFC7231

Of course when used the developer is encourage to mix the response to have a better understanding of the status code. Hope you like the addition.

I have updated the Unit test accordingly
