### PR TITLE
Status classes

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,8 @@ echo $Httpstatus->hasStatusCode(601); // false
 // check if reason phrase exists
 echo $Httpstatus->hasReasonPhrase('Method Not Allowed'); // true
 echo $Httpstatus->hasReasonPhrase('Does not exist'); // false
+// determine the type (or "class") of the code
+echo $Httpstatus->getResponseClass(503); // Httpstatus::CLASS_SERVER_ERROR
 // using constants
 echo $Httpstatus::HTTP_CREATED; // 201
 ```

--- a/src/Httpstatus.php
+++ b/src/Httpstatus.php
@@ -18,6 +18,15 @@ class Httpstatus implements Countable, IteratorAggregate
     const MAXIMUM = 599;
 
     /**
+     * The first digit of the Status-Code defines the class of response
+     */
+    const CLASS_INFORMATIONAL = 1;
+    const CLASS_SUCCESS = 2;
+    const CLASS_REDIRECTION = 3;
+    const CLASS_CLIENT_ERROR = 4;
+    const CLASS_SERVER_ERROR = 5;
+
+    /**
      * Every standard HTTP status code as a constant
      */
     const HTTP_CONTINUE = 100;
@@ -324,5 +333,30 @@ class Httpstatus implements Countable, IteratorAggregate
         }
 
         return true;
+    }
+
+    /**
+     * Determines the response class of a response code
+     *
+     * See the `CLASS_` constants for possible return values
+     *
+     * @param int $statusCode
+     *
+     * @throws InvalidArgumentException If the requested $statusCode is not valid
+     *
+     * @return int
+     */
+    public function getResponseClass($statusCode)
+    {
+        $statusCode = $this->filterHttpStatusCode($statusCode);
+        $firstDigit = (int) substr($statusCode, 0, 1);
+
+        switch ($firstDigit) {
+            case 1: return self::CLASS_INFORMATIONAL;
+            case 2: return self::CLASS_SUCCESS;
+            case 3: return self::CLASS_REDIRECTION;
+            case 4: return self::CLASS_CLIENT_ERROR;
+            case 5: return self::CLASS_SERVER_ERROR;
+        }
     }
 }

--- a/tests/HttpstatusTest.php
+++ b/tests/HttpstatusTest.php
@@ -254,4 +254,56 @@ class HttpstatusTest extends PHPUnit_Framework_TestCase
         $this->assertSame(true, $Httpstatus->hasReasonPhrase('Custom error code'), 'Expected $Httpstatus->hasReasonPhrase("Custom error code") to return true');
         $this->assertSame(false, $Httpstatus->hasReasonPhrase('MissingReasonPhrase'), 'Expected $Httpstatus->hasReasonPhrase("MissingReasonPhrase") to return false');
     }
+
+    /**
+     * @param int $expectedClass
+     * @param int $statusCode
+     *
+     * @dataProvider responseClasses
+     */
+    public function testGetResponseClass($expectedClass, $statusCode)
+    {
+        $this->assertSame($expectedClass, $this->httpStatus->getResponseClass($statusCode));
+    }
+
+    /**
+     * @return array
+     */
+    public function responseClasses()
+    {
+        return [
+            [Httpstatus::CLASS_INFORMATIONAL, Httpstatus::HTTP_CONTINUE],
+            [Httpstatus::CLASS_INFORMATIONAL, Httpstatus::HTTP_SWITCHING_PROTOCOLS],
+            [Httpstatus::CLASS_SUCCESS, Httpstatus::HTTP_OK],
+            [Httpstatus::CLASS_SUCCESS, Httpstatus::HTTP_PARTIAL_CONTENT],
+            [Httpstatus::CLASS_REDIRECTION, Httpstatus::HTTP_MULTIPLE_CHOICES],
+            [Httpstatus::CLASS_REDIRECTION, Httpstatus::HTTP_MOVED_PERMANENTLY],
+            [Httpstatus::CLASS_CLIENT_ERROR, Httpstatus::HTTP_BAD_REQUEST],
+            [Httpstatus::CLASS_CLIENT_ERROR, Httpstatus::HTTP_NOT_FOUND],
+            [Httpstatus::CLASS_SERVER_ERROR, Httpstatus::HTTP_INTERNAL_SERVER_ERROR],
+            [Httpstatus::CLASS_SERVER_ERROR, Httpstatus::HTTP_GATEWAY_TIMEOUT],
+        ];
+    }
+
+    /**
+     * @expectedException InvalidArgumentException
+     * @dataProvider      invalidResponseCodes
+     */
+    public function testGetResponseClassForInvalidCodes($statusCode)
+    {
+        $this->httpStatus->getResponseClass($statusCode);
+    }
+
+    /**
+     * @return array
+     */
+    public function invalidResponseCodes()
+    {
+        return [
+            [0],
+            [000],
+            [600],
+            ['Not Found'],
+        ];
+    }
 }


### PR DESCRIPTION
**Please note that this includes the same commit made in #8, as it is a dependency of this functionality.**  I'd recommend reviewing and merging that first.

---

Per [RFC 7231 Section 6](https://tools.ietf.org/html/rfc7231#section-6):

> a client MUST understand the class of any status code, as indicated by the
> first digit, and treat an unrecognized status code as being equivalent to
> the x00 status code of that class

This commit provides the functionality and constants needed to determine and
work with those classes.
