### PR TITLE
Improve reason phrase validation

### DIFF
--- a/src/Httpstatus.php
+++ b/src/Httpstatus.php
@@ -241,17 +241,25 @@ class Httpstatus implements Countable, IteratorAggregate
      *
      * @param string $text
      *
-     * @throws InvalidArgumentException if the reason phrase is invalid
+     * @throws InvalidArgumentException if the reason phrase is not a string
+     * @throws InvalidArgumentException if the reason phrase contains carriage return characters
+     *
+     * @see http://tools.ietf.org/html/rfc2616#section-6.1.1
      *
      * @return string
      */
     protected function filterReasonPhrase($text)
     {
-        if ((is_object($text) && method_exists($text, '__toString')) || is_string($text)) {
-            return trim($text);
+        if (!(is_object($text) && method_exists($text, '__toString')) && !is_string($text)) {
+            throw new InvalidArgumentException('The reason phrase must be a string');
         }
 
-        throw new InvalidArgumentException('The reason phrase must be a string');
+        $text = trim($text);
+        if (preg_match(',[\r\n],', $text)) {
+            throw new InvalidArgumentException('The reason phrase can not contain carriage return characters');
+        }
+
+        return $text;
     }
 
     /**

--- a/tests/HttpstatusTest.php
+++ b/tests/HttpstatusTest.php
@@ -72,24 +72,14 @@ class HttpstatusTest extends PHPUnit_Framework_TestCase
     public function testCountable()
     {
         $this->assertInstanceOf('\Countable', $this->httpStatus);
-        $this->assertSame(
-            count($this->statuses),
-            $this->httpStatus->count());
+        $this->assertSame(count($this->statuses), $this->httpStatus->count());
     }
 
     public function testIteratorAggregate()
     {
         $this->assertInstanceOf('\IteratorAggregate', $this->httpStatus);
-
         foreach ($this->httpStatus as $code => $text) {
-            $codes[$code] = $text;
-        }
-
-        foreach ($this->statuses as $code => $text) {
-            $this->assertSame(
-                $codes[$code],
-                $text
-            );
+            $this->assertSame($this->statuses[$code], $text);
         }
     }
 
@@ -151,6 +141,16 @@ class HttpstatusTest extends PHPUnit_Framework_TestCase
                 constant($prefix.strtoupper(str_replace([' ', '-', 'HTTP_'], ['_', '_', ''], $text)))
             );
         }
+    }
+
+    /**
+     * @expectedException        InvalidArgumentException
+     * @expectedExceptionMessage The reason phrase can not contain carriage return characters
+     */
+    public function testInvalidReasonPhraseWithCarriageReturnCharacter()
+    {
+        $reasonPhrase = 'Hello There'.PHP_EOL.'How Are you!!';
+        (new Httpstatus())->mergeHttpStatus(404, $reasonPhrase);
     }
 
     /**


### PR DESCRIPTION
an InvalidArgumentException is thrown if the reason phrase
contains carriage return characters as per RFC2616

see http://tools.ietf.org/html/rfc2616#section-6.1.1
