### PR TITLE
Add support for RFC 2324

### DIFF
--- a/src/Httpstatus.php
+++ b/src/Httpstatus.php
@@ -66,6 +66,7 @@ class Httpstatus implements Countable, IteratorAggregate
       415 => 'Unsupported Media Type',
       416 => 'Range Not Satisfiable',
       417 => 'Expectation Failed',
+      418 => 'I\'m a teapot',
       421 => 'Misdirected Request',
       422 => 'Unprocessable Entity',
       423 => 'Locked',

--- a/src/Httpstatuscodes.php
+++ b/src/Httpstatuscodes.php
@@ -47,6 +47,7 @@ interface Httpstatuscodes
     const HTTP_UNSUPPORTED_MEDIA_TYPE = 415;
     const HTTP_RANGE_NOT_SATISFIABLE = 416;
     const HTTP_EXPECTATION_FAILED = 417;
+    const HTTP_IM_A_TEAPOT = 418;           // RFC2324
     const HTTP_MISDIRECTED_REQUEST = 421;
     const HTTP_UNPROCESSABLE_ENTITY = 422;                                        // RFC4918
     const HTTP_LOCKED = 423;                                                      // RFC4918

--- a/tests/HttpstatuscodesTest.php
+++ b/tests/HttpstatuscodesTest.php
@@ -37,7 +37,7 @@ class HttpstatuscodesTest extends PHPUnit_Framework_TestCase
         foreach ($this->statuses as $code => $text) {
             $this->assertSame(
                 $code,
-                constant($prefix.strtoupper(str_replace([' ', '-', 'HTTP_'], ['_', '_', ''], $text)))
+                constant($prefix.strtoupper(str_replace([' ', '-', 'HTTP_', "'"], ['_', '_', '', ''], $text)))
             );
         }
     }

--- a/tests/data/http-status-codes-1.csv
+++ b/tests/data/http-status-codes-1.csv
@@ -43,7 +43,8 @@ Value,Description,Reference
 415,Unsupported Media Type,"[RFC7231, Section 6.5.13]"
 416,Range Not Satisfiable,"[RFC7233, Section 4.4]"
 417,Expectation Failed,"[RFC7231, Section 6.5.14]"
-418-420,Unassigned,
+418,I'm a teapot,"[RFC2324, Section 2.3.2]"
+419-420,Unassigned,
 421,Misdirected Request,"[RFC7540, Section 9.1.2]"
 422,Unprocessable Entity,[RFC4918]
 423,Locked,[RFC4918]


### PR DESCRIPTION
- Adds RFC 2324 Status code 418 to the http-status-codes-1.csv datafile
- Adds HTTP Status code constant & Reason Phrase
- Adds ' (single quote) as an ignored character when automatically determining constant names

---

RFC 2324 is the widely known Hypertext Coffee Pot Control Protocol - originally created as an April Fools' Day Joke - however widely implemented by production servers as a joke.  Perhaps most notably [Google](https://www.google.com/teapot)
