### PR TITLE
Add HTTP 451 Unavailable For Legal Reasons

### DIFF
--- a/src/Httpstatus.php
+++ b/src/Httpstatus.php
@@ -74,6 +74,7 @@ class Httpstatus implements Countable, IteratorAggregate
       428 => 'Precondition Required',
       429 => 'Too Many Requests',
       431 => 'Request Header Fields Too Large',
+      451 => 'Unavailable For Legal Reasons',
       500 => 'Internal Server Error',
       501 => 'Not Implemented',
       502 => 'Bad Gateway',

--- a/src/Httpstatuscodes.php
+++ b/src/Httpstatuscodes.php
@@ -56,6 +56,7 @@ interface Httpstatuscodes
     const HTTP_PRECONDITION_REQUIRED = 428;                                       // RFC6585
     const HTTP_TOO_MANY_REQUESTS = 429;                                           // RFC6585
     const HTTP_REQUEST_HEADER_FIELDS_TOO_LARGE = 431;                             // RFC6585
+    const HTTP_UNAVAILABLE_FOR_LEGAL_REASONS = 451;
     const HTTP_INTERNAL_SERVER_ERROR = 500;
     const HTTP_NOT_IMPLEMENTED = 501;
     const HTTP_BAD_GATEWAY = 502;

--- a/tests/data/http-status-codes-1.csv
+++ b/tests/data/http-status-codes-1.csv
@@ -55,7 +55,9 @@ Value,Description,Reference
 429,Too Many Requests,[RFC6585]
 430,Unassigned,
 431,Request Header Fields Too Large,[RFC6585]
-432-499,Unassigned,
+432-450,Unassigned,
+451,Unavailable For Legal Reasons,[TBA]
+452-499,Unassigned,
 500,Internal Server Error,"[RFC7231, Section 6.6.1]"
 501,Not Implemented,"[RFC7231, Section 6.6.2]"
 502,Bad Gateway,"[RFC7231, Section 6.6.3]"


### PR DESCRIPTION
This new status code has been approved.  It is awaiting final publication and an RFC number assignment.  According to Mark Nottingham, the IETF HTTP Working Group Chair, “you can start using it now.”  (Although I wouldn't be opposed to waiting until the final RFC is published)
- https://datatracker.ietf.org/doc/draft-ietf-httpbis-legally-restricted-status/
- http://thenextweb.com/dd/2015/12/21/theres-now-an-official-http-status-code-for-legal-takedowns-451/
