### PR TITLE
Return boolean from has* methods

### DIFF
--- a/src/Httpstatus.php
+++ b/src/Httpstatus.php
@@ -271,7 +271,11 @@ class Httpstatus implements Countable, IteratorAggregate
      */
     public function hasStatusCode($statusCode)
     {
-        $statusCode = $this->filterStatusCode($statusCode);
+        try {
+            $statusCode = $this->filterStatusCode($statusCode);
+        } catch (InvalidArgumentException $e) {
+            return false;
+        }
 
         return isset($this->httpStatus[$statusCode]);
     }
@@ -287,7 +291,11 @@ class Httpstatus implements Countable, IteratorAggregate
      */
     public function hasReasonPhrase($statusText)
     {
-        $statusText = $this->filterReasonPhrase($statusText);
+        try {
+            $statusText = $this->filterReasonPhrase($statusText);
+        } catch (InvalidArgumentException $e) {
+            return false;
+        }
 
         return (bool) $this->fetchStatusCode($statusText);
     }

--- a/tests/HttpstatusTest.php
+++ b/tests/HttpstatusTest.php
@@ -230,6 +230,10 @@ class HttpstatusTest extends PHPUnit_Framework_TestCase
         $this->assertSame(true, $Httpstatus->hasStatusCode(100), 'Expected $Httpstatus->hasStatusCode("100") to return true');
         $this->assertSame(true, $Httpstatus->hasStatusCode(498), 'Expected $Httpstatus->hasStatusCode("498") to return true');
         $this->assertSame(false, $Httpstatus->hasStatusCode(499), 'Expected $Httpstatus->hasStatusCode("499") to return false');
+
+        // Outside of normal range
+        $this->assertSame(false, $Httpstatus->hasStatusCode(0), 'Expected $Httpstatus->hasStatusCode("0") to return false');
+        $this->assertSame(false, $Httpstatus->hasStatusCode(600), 'Expected $Httpstatus->hasStatusCode("600") to return false');
     }
 
     public function testHasReasonPhrase()
@@ -242,6 +246,12 @@ class HttpstatusTest extends PHPUnit_Framework_TestCase
         $this->assertSame(true, $Httpstatus->hasReasonPhrase('Continue'), 'Expected $Httpstatus->hasReasonPhrase("Continue") to return true');
         $this->assertSame(true, $Httpstatus->hasReasonPhrase('Custom error code'), 'Expected $Httpstatus->hasReasonPhrase("Custom error code") to return true');
         $this->assertSame(false, $Httpstatus->hasReasonPhrase('MissingReasonPhrase'), 'Expected $Httpstatus->hasReasonPhrase("MissingReasonPhrase") to return false');
+
+        // Invalid phrases
+        $this->assertSame(false, $Httpstatus->hasReasonPhrase(false), 'Expected $Httpstatus->hasReasonPhrase(false) to return false');
+        $this->assertSame(false, $Httpstatus->hasReasonPhrase(0), 'Expected $Httpstatus->hasReasonPhrase(0) to return false');
+        $this->assertSame(false, $Httpstatus->hasReasonPhrase([]), 'Expected $Httpstatus->hasReasonPhrase([]) to return false');
+        $this->assertSame(false, $Httpstatus->hasReasonPhrase("a\nb"), 'Expected $Httpstatus->hasReasonPhrase("a\nb") to return false');
     }
 
     /**


### PR DESCRIPTION
When a `has*` method throws an exception it results in much less
elegant code and can break up simple logic. By always returning a
boolean for `has*` methods intent is much more clear.

Fixes #16
