### PR TITLE
Compatible php8.1

### DIFF
--- a/src/Httpstatus.php
+++ b/src/Httpstatus.php
@@ -47,7 +47,7 @@ class Httpstatus implements Countable, IteratorAggregate
     /**
      * {@inheritdoc}
      */
-    public function count()
+    public function count(): int
     {
         return count($this->httpStatus);
     }
@@ -55,7 +55,7 @@ class Httpstatus implements Countable, IteratorAggregate
     /**
      * {@inheritdoc}
      */
-    public function getIterator()
+    public function getIterator(): \Traversable
     {
         return new ArrayIterator($this->httpStatus);
     }

--- a/src/Httpstatus.php
+++ b/src/Httpstatus.php
@@ -47,7 +47,8 @@ class Httpstatus implements Countable, IteratorAggregate
     /**
      * {@inheritdoc}
      */
-    public function count(): int
+    #[\ReturnTypeWillChange]
+    public function count()
     {
         return count($this->httpStatus);
     }
@@ -55,7 +56,8 @@ class Httpstatus implements Countable, IteratorAggregate
     /**
      * {@inheritdoc}
      */
-    public function getIterator(): \Traversable
+    #[\ReturnTypeWillChange]
+    public function getIterator()
     {
         return new ArrayIterator($this->httpStatus);
     }


### PR DESCRIPTION
```
2021-12-06 02:39:53.161554  ERROR  Return type of Lukasoppermann\Httpstatus\Httpstatus::count() should either be compatible with Countable::count(): int, or the #[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice in /Users/liujian/Code/mixphp/mix/examples/api-skeleton/vendor/lukasoppermann/http-status/src/Httpstatus.php on line 50 in /Users/liujian/Code/mixphp/mix/examples/api-skeleton/src/Error.php on line 39
2021-12-06 02:39:53.161875  ERROR  Return type of Lukasoppermann\Httpstatus\Httpstatus::getIterator() should either be compatible with IteratorAggregate::getIterator(): Traversable, or the #[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice in /Users/liujian/Code/mixphp/mix/examples/api-skeleton/vendor/lukasoppermann/http-status/src/Httpstatus.php on line 58 in /Users/liujian/Code/mixphp/mix/examples/api-skeleton/src/Error.php on line 39
```