### PR TITLE
fix type error

### DIFF
--- a/src/Httpstatus.php
+++ b/src/Httpstatus.php
@@ -152,7 +152,7 @@ class Httpstatus implements Countable, IteratorAggregate
     /**
      * Get the text for a given status code.
      *
-     * @param string $statusCode http status code
+     * @param int $statusCode http status code
      *
      * @throws InvalidArgumentException If the requested $statusCode is not valid
      * @throws OutOfBoundsException     If the requested $statusCode is not found


### PR DESCRIPTION
I get errors from phpstan when using this library
```
Parameter #1 $statusCode of method Lukasoppermann\Httpstatus\Httpstatus::getReasonPhrase() expects string, int given.
```
I think this patch should fix it.