### PR TITLE
Allowed "de" value for Httpstatus::setLanguage

### DIFF
--- a/src/Httpstatus.php
+++ b/src/Httpstatus.php
@@ -27,7 +27,7 @@ class Httpstatus implements Countable, IteratorAggregate
     const CLASS_SERVER_ERROR = 5;
 
     /**
-     * Collection of HTTP Statusses
+     * Collection of HTTP Statuses
      * @var array<int,string> Status code as key and reason phrase as value
      */
     protected $httpStatus;
@@ -90,7 +90,7 @@ class Httpstatus implements Countable, IteratorAggregate
      * Add or Update the HTTP Status array.
      *
      * @param int    $code a HTTP status Code
-     * @param string $text a associated reason phrase
+     * @param string $text an associated reason phrase
      *
      * @throws RuntimeException if the HTTP status code or the reason phrase are invalid
      */
@@ -277,7 +277,7 @@ class Httpstatus implements Countable, IteratorAggregate
 
 
     /**
-     * Sets the http status code to the choosen language
+     * Sets the http status code to the chosen language
      *
      * @param string $language
      *
@@ -285,7 +285,7 @@ class Httpstatus implements Countable, IteratorAggregate
      */
     public function setLanguage($language)
     {
-        $supportedLanguages = ['en', 'fr'];
+        $supportedLanguages = ['en', 'fr', 'de'];
         if (!in_array($language, $supportedLanguages)) {
             throw new InvalidArgumentException('Unsupported language '.$language);
         }

--- a/tests/HttpstatusDeTest.php
+++ b/tests/HttpstatusDeTest.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace Lukasoppermann\Httpstatus\tests;
+
+class HttpstatusDeTest extends HttpstatusTest
+{
+    protected $language = 'de';
+}

--- a/tests/data/http-status-codes-de.csv
+++ b/tests/data/http-status-codes-de.csv
@@ -1,0 +1,62 @@
+Value,Description,Reference
+100,Fortfahren,"[RFC7231, Section 6.2.1]"
+101,Protokolländerung,"[RFC7231, Section 6.2.2]"
+102,Verarbeiten,[RFC2518]
+200,OK,
+201,Erstellt,"[RFC7231, Section 6.3.1]"
+202,Angenommen,"[RFC7231, Section 6.3.2]"
+203,Nicht-Authoritative Information,"[RFC7231, Section 6.3.3]"
+204,Kein Inhalt,"[RFC7231, Section 6.3.4]"
+205,Inhalt zurücksetzen,"[RFC7231, Section 6.3.5]"
+206,Teilweiser Inhalt,"[RFC7231, Section 6.3.6]"
+207,Mehrfache Zustände,"[RFC7233, Section 4.1]"
+208,Bereits übermittelt,[RFC4918]
+226,IM benutzt,[RFC5842]
+300,Mehrfach verwendet,
+301,Dauerhaft umgezogen,[RFC3229]
+302,Gefunden,
+303,Verweis auf,"[RFC7231, Section 6.4.1]"
+304,Nicht verändert,"[RFC7231, Section 6.4.2]"
+305,Proxy benutzen,"[RFC7231, Section 6.4.3]"
+307,Vorrübergehende Weiterleitung,"[RFC7231, Section 6.4.4]"
+308,Permanente Weiterleitung,"[RFC7232, Section 4.1]"
+400,Fehlerhafte Anfrage,"[RFC7231, Section 6.4.5]"
+401,Nicht authorisiert,"[RFC7231, Section 6.4.6]"
+402,Bezahlung erforderlich,"[RFC7231, Section 6.4.7]"
+403,Verboten,[RFC7538]
+404,Nicht gefunden,
+405,Methode nicht erlaubt,"[RFC7231, Section 6.5.1]"
+406,Nicht akzeptabel,"[RFC7235, Section 3.1]"
+407,Proxy Authentifizierung erforderlich,"[RFC7231, Section 6.5.2]"
+408,Zeitüberschreitung der Anfrage,"[RFC7231, Section 6.5.3]"
+409,Konflikt,"[RFC7231, Section 6.5.4]"
+410,Nicht mehr vorhanden,"[RFC7231, Section 6.5.5]"
+411,Länge erforderlich,"[RFC7231, Section 6.5.6]"
+412,Vorbedingung fehlgeschlagen,"[RFC7235, Section 3.2]"
+413,Inhalt zu groß,"[RFC7231, Section 6.5.7]"
+414,URI zu lang,"[RFC7231, Section 6.5.8]"
+415,Nicht unterstützer Medientyp,"[RFC7231, Section 6.5.9]"
+416,Bereich nicht adressierbar,"[RFC7231, Section 6.5.10]"
+417,Expectation fehlgeschlagen,"[RFC7232, Section 4.2]"
+418,Ich bin ein Teekessel,"[RFC7231, Section 6.5.11]"
+421,Misdirected Request,"[RFC7231, Section 6.5.12]"
+422,Nicht verarbeitbare Entität,"[RFC7231, Section 6.5.13]"
+423,Gesperrt,"[RFC7233, Section 4.4]"
+424,Fehlgeschlagene Abhängigkeit,"[RFC7231, Section 6.5.14]"
+425,Zu früh,"[RFC2324, Section 2.3.2]"
+426,Upgrade notwendig,
+428,Vorbedingung vorausgesetzt,"[RFC7540, Section 9.1.2]"
+429,Zu viele Anfragen,[RFC4918]
+431,Header Felder sind zu groß,[RFC4918]
+451,Nicht erreichbar aus rechtlichen Gründen,[RFC4918]
+500,Interner Server Fehler,"[RFC8470, Section 5.2]"
+501,Nicht implementiert,"[RFC7231, Section 6.5.15]"
+502,Kein Endpunkt (Serverfehler),
+503,Dienst nicht erreichbar,[RFC6585]
+504,Zeitüberschreitung beim Endpunkt,[RFC6585]
+505,HTTP Version nicht unterstützt,
+506,Endpunkt verhandelt selbst,[RFC6585]
+507,Unzureichender Speicher,
+508,Schleife entdeckt,[TBA]
+510,Nicht erweitert,
+511,Netzwerkauthentifizierung erforderlich,"[RFC7231, Section 6.6.1]"


### PR DESCRIPTION
As a complement to [this previous pull request](https://github.com/lukasoppermann/http-status/pull/30), I added `de` as an allowed language value for `Httpstatus::setLanguage`.

With this I added `HttpstatusDeTest.php` and `http-status-codes-de.csv`. The CSV data contains copy-pasted values from `de.php` and RFC references from `http-status-codes-fr.csv`.

Finally, I fixed some typos in `Httpstatus`.

### Tests

Tests in `HttpstatusDeTest.php` are passing, ran them in PHP 8.2.0.

Some other tests produce errors, but those are only errors I patched in [this other pull request](https://github.com/lukasoppermann/http-status/pull/31), so once it is accepted, if it is, the tests should all work flawlessly.

### About the change log

I did not update the CHANGELOG.md because it hasn't been updated in 8 years and I assumed it is more of a template than an actual change log. Let me know if you need me to update it.